### PR TITLE
라우터 이동 구현 및 관련 컴포넌트 생성

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,21 @@
+import { ThemeProvider } from 'styled-components';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import GlobalStyle from 'theme/GlobalStyles';
+import theme from 'theme/theme';
+import VendingMachine from 'Pages/VendingMachine';
+import Wallet from 'Pages/Wallet';
+
 function App() {
   return (
-    <div className="App"></div>
+    <ThemeProvider theme={theme}>
+      <GlobalStyle />
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<VendingMachine />} />
+          <Route path="wallet" element={<Wallet />} />
+        </Routes>
+      </BrowserRouter>
+    </ThemeProvider>
   );
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import GlobalStyle from 'theme/GlobalStyles';
 import theme from 'theme/theme';
 import VendingMachine from 'Pages/VendingMachine';
 import Wallet from 'Pages/Wallet';
+import NotFound from 'Pages/NotFound';
 
 function App() {
   return (
@@ -13,6 +14,7 @@ function App() {
         <Routes>
           <Route path="/" element={<VendingMachine />} />
           <Route path="wallet" element={<Wallet />} />
+          <Route path="*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>
     </ThemeProvider>

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import { ThemeProvider } from 'styled-components';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import GlobalStyle from 'theme/GlobalStyles';
 import theme from 'theme/theme';
+import Navigation from 'components/Navigation';
 import VendingMachine from 'Pages/VendingMachine';
 import Wallet from 'Pages/Wallet';
 import NotFound from 'Pages/NotFound';
@@ -11,6 +12,7 @@ function App() {
     <ThemeProvider theme={theme}>
       <GlobalStyle />
       <BrowserRouter>
+        <Navigation />
         <Routes>
           <Route path="/" element={<VendingMachine />} />
           <Route path="wallet" element={<Wallet />} />

--- a/src/Pages/NotFound.jsx
+++ b/src/Pages/NotFound.jsx
@@ -1,0 +1,58 @@
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+export default function NotFound() {
+  let navigate = useNavigate();
+
+  const moveBackPage = () => {
+    navigate(-1);
+  };
+
+  const moveMachinePage = () => {
+    navigate('/');
+  };
+
+  return (
+    <NotFoundContainer>
+      <Message>⛔️ 유효하지 않은 페이지입니다! ⛔️</Message>
+      <BtnWrapper>
+        <PageMoveBtn onClick={moveBackPage}>🔙 뒤로가기</PageMoveBtn>
+        <span>또는</span>
+        <PageMoveBtn onClick={moveMachinePage}>🧃 자판기로 가기</PageMoveBtn>
+      </BtnWrapper>
+    </NotFoundContainer>
+  );
+}
+
+const NotFoundContainer = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 64px;
+  border: 1px solid ${({ theme }) => theme.colors.black};
+  border-radius: 20px;
+  text-align: center;
+`;
+
+const Message = styled.p`
+  margin-bottom: 40px;
+  width: 500px;
+  ${({ theme }) => theme.fontStyles.display};
+`;
+
+const BtnWrapper = styled.div`
+  span {
+    padding: 8px;
+    ${({ theme }) => theme.fontStyles.smallRegular};
+  }
+`;
+
+const PageMoveBtn = styled.button`
+  ${({ theme }) => theme.fontStyles.xLargeBold};
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.blue};
+    transition: all 0.4s ease-in-out;
+  }
+`;

--- a/src/Pages/VendingMachine.jsx
+++ b/src/Pages/VendingMachine.jsx
@@ -1,0 +1,3 @@
+export default function VendingMachine() {
+  return <p>자판기</p>;
+}

--- a/src/Pages/Wallet.jsx
+++ b/src/Pages/Wallet.jsx
@@ -1,0 +1,3 @@
+export default function Wallet() {
+  return <p>지갑</p>;
+}

--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
@@ -10,6 +10,10 @@ const Navigation = () => {
     if (!e.target.id) return;
     setFocusLink(e.target.id);
   };
+
+  useEffect(() => {
+    setFocusLink(location.pathname);
+  }, [location.pathname]);
 
   const MACHINE_ID = '/';
   const WALLET_ID = '/wallet';

--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import styled, { css } from 'styled-components';
+
+const Navigation = () => {
+  const location = useLocation();
+  const [focusLink, setFocusLink] = useState(location.pathname);
+
+  const onClick = e => {
+    if (!e.target.id) return;
+    setFocusLink(e.target.id);
+  };
+
+  const MACHINE_ID = '/';
+  const WALLET_ID = '/wallet';
+
+  return (
+    <>
+      {(location.pathname === '/' || location.pathname === '/wallet') && (
+        <Nav onClick={onClick}>
+          <StyeldLink to="/" focus={focusLink} id={MACHINE_ID}>
+            🧃 자판기
+          </StyeldLink>
+          <StyeldLink to="wallet" focus={focusLink} id={WALLET_ID}>
+            지갑 💵
+          </StyeldLink>
+        </Nav>
+      )}
+    </>
+  );
+};
+
+const Nav = styled.nav`
+  display: flex;
+  justify-content: center;
+  text-align: center;
+  margin-top: 20px;
+`;
+
+const StyeldLink = styled(Link)`
+  padding: 32px;
+  ${({ theme }) => theme.fontStyles.xLargeBold};
+  ${props =>
+    props.focus === props.id &&
+    css`
+      background: ${({ theme }) => theme.colors.green};
+      color: ${({ theme }) => theme.colors.white};
+    `};
+
+  &:first-child {
+    border: 1px solid ${({ theme }) => theme.colors.green};
+    border-right: none;
+    border-radius: 999px 0 0 999px;
+  }
+
+  &:last-child {
+    border: 1px solid ${({ theme }) => theme.colors.green};
+    border-radius: 0 999px 999px 0;
+  }
+`;
+
+export default Navigation;

--- a/src/theme/GlobalStyles.jsx
+++ b/src/theme/GlobalStyles.jsx
@@ -1,0 +1,26 @@
+import { createGlobalStyle } from 'styled-components';
+import reset from 'styled-reset';
+
+const GlobalStyle = createGlobalStyle`
+  ${reset};
+
+  * {
+    margin: 0;
+    padding: 0;  
+    box-sizing: border-box;
+  }
+
+  a {
+    text-decoration: none;
+    color: ${({ theme }) => theme.colors.black};
+  }
+
+  button {
+    border: none;
+    outline: none;
+    background: transparent;
+    cursor: pointer;
+  }
+`;
+
+export default GlobalStyle;

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -1,0 +1,69 @@
+const colors = {
+  black: '#1B1B1B',
+  gray1: '#3F3F3F',
+  gray2: '#777777',
+  gray3: '#BCBCBC',
+  gray4: '#EBEBEB',
+  offWhite: '#F8F7F7',
+  white: '#FFFFFF',
+  green: '#14A05C',
+  orange: '#FF8E14',
+  blue: '#4186f1',
+  red: '#F5462F',
+};
+
+const fontStyles = {
+  display: {
+    fontWeight: 700,
+    fontSize: '36px',
+  },
+  xLargeBold: {
+    fontWeight: 500,
+    fontSize: '24px',
+    lineHeight: '38px',
+  },
+  largeRegular: {
+    fontWeight: 400,
+    fontSize: '20px',
+    lineHeight: '30px',
+  },
+  largeBold: {
+    fontWeight: 500,
+    fontSize: '20px',
+    lineHeight: '30px',
+  },
+  mediumRegular: {
+    fontWeight: 400,
+    fontSize: '16px',
+    lineHeight: '26px',
+  },
+  mediumBold: {
+    fontWeight: 500,
+    fontSize: '16px',
+    lineHeight: '26px',
+  },
+  smallRegular: {
+    fontWeight: 400,
+    fontSize: '14px',
+    lineHeight: '24px',
+  },
+  smallBold: {
+    fontWeight: 500,
+    fontSize: '14px',
+    lineHeight: '24px',
+  },
+  xSmallRegular: {
+    fontWeight: 400,
+    fontSize: '12px',
+    lineHeight: '18px',
+  },
+  xSmallBold: {
+    fontWeight: 500,
+    fontSize: '12px',
+    lineHeight: '18px',
+  },
+};
+
+const theme = { colors, fontStyles };
+
+export default theme;


### PR DESCRIPTION
### Done: #3

https://user-images.githubusercontent.com/85747667/167526273-a67708a6-2cf8-49bf-b9d2-379aef343749.mov


#### Navigation 컴포넌트 구현
- Navigation 컴포넌트 클릭시 라우터 이동 (react-router-dom의 Link 컴포넌트 사용)
    - 루트 경로: 자판기 컴포넌트가 보이도록 함
    - wallet 경로: 지갑 컴포넌트가 보이도록 함
- 라우터 이동시 Navigation 컴포넌트의 배경색이 변경됨

#### NotFound 컴포넌트 구현
- 그 외 경로 진입시 NotFound 컴포넌트가 보이도록 함
    - 뒤로가기 버튼과 루트 페이지로 가는 버튼 구현