### PR TITLE
기존 UI 수정 및 지갑 UI 구현

### DIFF
--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -38,7 +38,7 @@ const Nav = styled.nav`
   display: flex;
   justify-content: center;
   text-align: center;
-  margin: 40px;
+  margin: 20px;
 `;
 
 const StyeldLink = styled(Link)`

--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -38,28 +38,29 @@ const Nav = styled.nav`
   display: flex;
   justify-content: center;
   text-align: center;
-  margin-top: 20px;
+  margin: 40px;
 `;
 
 const StyeldLink = styled(Link)`
-  padding: 32px;
+  width: 136px;
+  padding: 12px 0;
   ${({ theme }) => theme.fontStyles.xLargeBold};
   ${props =>
     props.focus === props.id &&
     css`
-      background: ${({ theme }) => theme.colors.green};
+      background: ${({ theme }) => theme.colors.blue};
       color: ${({ theme }) => theme.colors.white};
     `};
 
   &:first-child {
-    border: 1px solid ${({ theme }) => theme.colors.green};
+    border: 1px solid ${({ theme }) => theme.colors.blue};
     border-right: none;
-    border-radius: 999px 0 0 999px;
+    border-radius: 8px 0 0 8px;
   }
 
   &:last-child {
-    border: 1px solid ${({ theme }) => theme.colors.green};
-    border-radius: 0 999px 999px 0;
+    border: 1px solid ${({ theme }) => theme.colors.blue};
+    border-radius: 0 8px 8px 0;
   }
 `;
 

--- a/src/components/VendingMachine/OrderContainer/Order.jsx
+++ b/src/components/VendingMachine/OrderContainer/Order.jsx
@@ -13,6 +13,7 @@ const OrderList = styled.ul`
   border-radius: 12px;
   overflow-y: auto;
   background: ${({ theme }) => theme.colors.offWhite};
+  box-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.37);
 `;
 
 // const Order = styled.li`

--- a/src/components/VendingMachine/OrderContainer/index.jsx
+++ b/src/components/VendingMachine/OrderContainer/index.jsx
@@ -10,52 +10,84 @@ export default function OrderContainer() {
   };
 
   return (
-    <OrderWrapper>
+    <Container>
       <UserOrder />
-      <div>
-        <InputCost type="text" placeholder="0 원" disabled />
+      <CostWrapper>
+        <InputWrapper>
+          <InputCost type="text" placeholder="0" />
+          <span>원</span>
+        </InputWrapper>
         <InputCostBtn onClick={moveWalletPage}>투입</InputCostBtn>
-      </div>
+      </CostWrapper>
       <ReturnCost>반환</ReturnCost>
-    </OrderWrapper>
+      <PickupBox>PUSH</PickupBox>
+    </Container>
   );
 }
 
-const OrderWrapper = styled.div`
+const Container = styled.div`
   padding: 20px;
   border: 1px solid black;
   border-left: none;
+  border-radius: 0 12px 12px 0;
   text-align: right;
   background: ${({ theme }) => theme.colors.green};
 `;
 
-const InputCost = styled.input`
-  margin-right: 8px;
-  padding: 8px;
-  text-align: right;
-  outline: none;
-  ${({ theme }) => theme.fontStyles.SmallBold};
+const CostWrapper = styled.div`
+  display: flex;
+  margin-bottom: 12px;
+`;
 
-  &:disabled {
-    border: none;
-    outline: none;
-    background: ${({ theme }) => theme.colors.white};
+const InputWrapper = styled.div`
+  margin-right: 12px;
+  padding: 0 8px;
+  border-radius: 4px;
+  background: ${({ theme }) => theme.colors.offWhite};
+  box-shadow: 0 2px 2px 0 rgba(38, 38, 135, 0.1);
+
+  span {
+    ${({ theme }) => theme.fontStyles.xSmallBold};
   }
 `;
 
+const InputCost = styled.input`
+  width: 80%;
+  padding: 8px;
+  text-align: right;
+  border: none;
+  outline: none;
+  background: transparent;
+  ${({ theme }) => theme.fontStyles.xSmallBold};
+`;
+
 const InputCostBtn = styled.button`
-  margin-bottom: 12px;
   padding: 8px;
   border: 1px solid transparent;
   border-radius: 50%;
   background: ${({ theme }) => theme.colors.gray3};
+  box-shadow: 0 2px 2px 0 rgba(38, 38, 135, 0.1);
   color: ${({ theme }) => theme.colors.gray1};
   ${({ theme }) => theme.fontStyles.xSmallBold};
 `;
 
 const ReturnCost = styled.button`
-  padding: 6px 24px;
+  padding: 4px 24px;
+  margin-bottom: 24px;
+  border-radius: 4px;
   background: ${({ theme }) => theme.colors.gray1};
+  box-shadow: 0 2px 2px 0 rgba(38, 38, 135, 0.3);
   color: ${({ theme }) => theme.colors.gray3};
   ${({ theme }) => theme.fontStyles.xSmallBold};
+`;
+
+const PickupBox = styled.div`
+  width: 100%;
+  padding: 28px;
+  border-radius: 8px;
+  text-align: center;
+  background: ${({ theme }) => theme.colors.gray1};
+  box-shadow: 0 4px 4px 0 rgba(38, 38, 135, 0.5);
+  color: ${({ theme }) => theme.colors.gray3};
+  ${({ theme }) => theme.fontStyles.largeBold};
 `;

--- a/src/components/VendingMachine/OrderContainer/index.jsx
+++ b/src/components/VendingMachine/OrderContainer/index.jsx
@@ -1,23 +1,29 @@
+import { useState, useEffect } from 'react';
+import setLocalString from 'utils/setLocalString';
 import styled from 'styled-components';
 import UserOrder from './Order';
-import { useNavigate } from 'react-router-dom';
 
 export default function OrderContainer() {
-  let navigate = useNavigate();
+  const [value, setValue] = useState('');
 
-  const moveWalletPage = () => {
-    navigate('/wallet');
+  const handleChange = e => {
+    if (e.target.value.length > 6) return;
+    setValue(setLocalString(e.target.value.replace(/[^0-9]/g, '')));
   };
+
+  useEffect(() => {
+    setValue(setLocalString(value.replace(/[^0-9]/g, '')));
+  }, [value]);
 
   return (
     <Container>
       <UserOrder />
       <CostWrapper>
         <InputWrapper>
-          <InputCost type="text" placeholder="0" />
+          <InputCost type="text" placeholder="0" value={value} onChange={handleChange} />
           <span>원</span>
         </InputWrapper>
-        <InputCostBtn onClick={moveWalletPage}>투입</InputCostBtn>
+        <InputCostBtn>투입</InputCostBtn>
       </CostWrapper>
       <ReturnCost>반환</ReturnCost>
       <PickupBox>PUSH</PickupBox>

--- a/src/components/VendingMachine/ProductContainer/Product.jsx
+++ b/src/components/VendingMachine/ProductContainer/Product.jsx
@@ -4,10 +4,12 @@ import setLocalString from 'utils/setLocalString';
 export default function Product({ info }) {
   return (
     <ProductWrapper>
-      <ProductButton stock={info.stock}>{info.name}</ProductButton>
-      <PriceWrapper>
-        <PriceState stock={info.stock} />
-        <Price stock={info.stock}>{info.stock ? setLocalString(info.price) + '원' : '품절'}</Price>
+      <ProductName stock={info.stock}>{info.name}</ProductName>
+      <PriceWrapper stock={info.stock}>
+        <span className="price_state"></span>
+        <button className="push_btn">
+          {info.stock ? setLocalString(info.price) + '원' : '품절'}
+        </button>
       </PriceWrapper>
     </ProductWrapper>
   );
@@ -19,7 +21,7 @@ const ProductWrapper = styled.div`
   align-items: center;
 `;
 
-const ProductButton = styled.button`
+const ProductName = styled.div`
   width: 100%;
   padding: 16px 12px;
   margin-bottom: 8px;
@@ -42,37 +44,43 @@ const ProductButton = styled.button`
 const PriceWrapper = styled.div`
   width: 70%;
   padding: 4px 8px;
-  border: 1px solid ${({ theme }) => theme.colors.gray4};
   border-radius: 999px;
   background: ${({ theme }) => theme.colors.gray3};
   cursor: default;
-`;
 
-const PriceState = styled.span`
-  display: inline-block;
-  padding: 4px;
-  margin-right: 6px;
-  border-radius: 50%;
+  .price_state {
+    display: inline-block;
+    padding: 4px;
+    margin-right: 6px;
+    border-radius: 50%;
+  }
 
-  ${props =>
-    props.stock
-      ? css`
-          background: ${({ theme }) => theme.colors.green};
-        `
-      : css`
-          background: ${({ theme }) => theme.colors.red};
-        `};
-`;
-
-const Price = styled.span`
-  ${({ theme }) => theme.fontStyles.xSmallBold};
+  .push_btn {
+    ${({ theme }) => theme.fontStyles.xSmallBold};
+  }
 
   ${props =>
     props.stock
       ? css`
-          color: ${({ theme }) => theme.colors.gray3};
+          border: 2px solid ${({ theme }) => theme.colors.gray4};
+
+          .price_state {
+            background: ${({ theme }) => theme.colors.green};
+          }
+
+          .push_btn {
+            color: ${({ theme }) => theme.colors.gray3};
+          }
         `
       : css`
-          color: ${({ theme }) => theme.colors.red};
+          border: 2px solid ${({ theme }) => theme.colors.red};
+
+          .price_state {
+            background: ${({ theme }) => theme.colors.red};
+          }
+
+          .push_btn {
+            color: ${({ theme }) => theme.colors.red};
+          }
         `};
 `;

--- a/src/components/VendingMachine/ProductContainer/Product.jsx
+++ b/src/components/VendingMachine/ProductContainer/Product.jsx
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import setLocalString from 'utils/setLocalString';
 
 export default function Product({ info }) {
   return (
@@ -6,7 +7,7 @@ export default function Product({ info }) {
       <ProductButton stock={info.stock}>{info.name}</ProductButton>
       <PriceWrapper>
         <PriceState stock={info.stock} />
-        <Price stock={info.stock}>{info.stock ? info.price + '원' : '품절'}</Price>
+        <Price stock={info.stock}>{info.stock ? setLocalString(info.price) + '원' : '품절'}</Price>
       </PriceWrapper>
     </ProductWrapper>
   );
@@ -39,7 +40,7 @@ const ProductButton = styled.button`
 `;
 
 const PriceWrapper = styled.div`
-  width: 65%;
+  width: 70%;
   padding: 4px 8px;
   border: 1px solid ${({ theme }) => theme.colors.gray4};
   border-radius: 999px;
@@ -50,7 +51,7 @@ const PriceWrapper = styled.div`
 const PriceState = styled.span`
   display: inline-block;
   padding: 4px;
-  margin-right: 4px;
+  margin-right: 6px;
   border-radius: 50%;
 
   ${props =>

--- a/src/components/VendingMachine/ProductContainer/index.jsx
+++ b/src/components/VendingMachine/ProductContainer/index.jsx
@@ -2,17 +2,29 @@ import styled from 'styled-components';
 import productsList from 'mock/Products';
 import Product from './Product';
 
-const GridContainer = styled.div`
+export default function ProductContainer() {
+  const list = productsList.map(product => <Product key={product.id} info={product}></Product>);
+
+  return (
+    <Container>
+      <GridWrapper>{list}</GridWrapper>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  padding: 20px;
+  border: 1px solid black;
+  background: ${({ theme }) => theme.colors.green};
+  border-radius: 12px 0 0 12px;
+`;
+
+const GridWrapper = styled.div`
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 10px;
   padding: 20px;
-  border: 1px solid black;
-  background: ${({ theme }) => theme.colors.green};
+  border-radius: 12px;
+  background: rgba(235, 235, 235, 0.8);
+  box-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.37);
 `;
-
-export default function ProductContainer() {
-  const list = productsList.map(product => <Product key={product.id} info={product}></Product>);
-
-  return <GridContainer>{list}</GridContainer>;
-}

--- a/src/components/VendingMachine/index.jsx
+++ b/src/components/VendingMachine/index.jsx
@@ -6,7 +6,6 @@ const MachineContainer = styled.div`
   display: flex;
   justify-content: center;
   text-align: center;
-  margin-top: 40px;
 `;
 
 export default function VendingMachine() {

--- a/src/components/Wallet/index.jsx
+++ b/src/components/Wallet/index.jsx
@@ -1,0 +1,73 @@
+import styled from 'styled-components';
+import walletInfo from 'mock/Wallet';
+import setLocalString from 'utils/setLocalString';
+
+const Money = ({ info }) => {
+  return (
+    <MoneyWrapper>
+      <span>{setLocalString(info.money)}원</span>
+      <button>{info.amount}개</button>
+    </MoneyWrapper>
+  );
+};
+
+export default function Wallet() {
+  const [moneyData] = walletInfo;
+  const moneyInfo = moneyData.money.map((money, index) => <Money key={index} info={money} />);
+  const totalMoney = moneyData.money.reduce((acc, cur) => acc + cur.money * cur.amount, 0);
+
+  return (
+    <WalletContainer>
+      <TotalAmount>총 금액: {setLocalString(totalMoney)}원</TotalAmount>
+      <WalletWrapper> {moneyInfo}</WalletWrapper>
+    </WalletContainer>
+  );
+}
+
+const WalletContainer = styled.div`
+  margin: 0 auto;
+  width: 50%;
+  padding: 20px;
+  border-radius: 12px;
+  background: rgba(235, 235, 235, 0.8);
+  box-shadow: 0 2px 16px 0 rgba(38, 38, 38, 0.37);
+`;
+
+const TotalAmount = styled.div`
+  margin: 0 auto;
+  width: 40%;
+  margin-bottom: 20px;
+  padding: 8px 12px;
+  border-radius: 12px;
+  text-align: center;
+  background: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.fontStyles.mediumBold};
+`;
+
+const WalletWrapper = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  padding: 12px;
+  border-radius: 8px;
+  background: ${({ theme }) => theme.colors.white};
+`;
+
+const MoneyWrapper = styled.div`
+  display: flex;
+  border: 1px solid transparent;
+
+  span {
+    padding: 8px;
+    width: 70%;
+    background: ${({ theme }) => theme.colors.gray4};
+    ${({ theme }) => theme.fontStyles.smallBold};
+  }
+
+  button {
+    width: 30%;
+    padding: 8px 4px;
+    background: ${({ theme }) => theme.colors.orange};
+    ${({ theme }) => theme.fontStyles.smallRegular};
+  }
+`;

--- a/src/mock/Wallet.js
+++ b/src/mock/Wallet.js
@@ -1,0 +1,15 @@
+const walletInfo = [
+  {
+    money: [
+      { money: 10, amount: 3 },
+      { money: 50, amount: 3 },
+      { money: 100, amount: 8 },
+      { money: 500, amount: 5 },
+      { money: 1000, amount: 4 },
+      { money: 5000, amount: 2 },
+      { money: 10000, amount: 1 },
+    ],
+  },
+];
+
+export default walletInfo;

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -37,7 +37,6 @@ const NotFoundContainer = styled.div`
 
 const Message = styled.p`
   margin-bottom: 40px;
-  width: 500px;
   ${({ theme }) => theme.fontStyles.display};
 `;
 

--- a/src/pages/Wallet.jsx
+++ b/src/pages/Wallet.jsx
@@ -1,3 +1,2 @@
-export default function Wallet() {
-  return <p>지갑</p>;
-}
+import Wallet from 'components/Wallet';
+export default Wallet;

--- a/src/utils/setLocalString.js
+++ b/src/utils/setLocalString.js
@@ -1,0 +1,2 @@
+const setLocalString = price => Number(price).toLocaleString();
+export default setLocalString;


### PR DESCRIPTION
### Done: #4, #5 

#### 자판기 UI
<img width="1438" alt="스크린샷 2022-05-11 오후 2 11 09" src="https://user-images.githubusercontent.com/85747667/167773619-06740e8d-5522-4e9c-9c1e-be4e45eeb8cc.png">

- 투입버튼 클릭시 지갑 페이지로 이동하는 기능 삭제 -> 요구사항에 맞지 않았음
- 금액 입력이 가능하도록 disabled 속성 제거
    - 만 자리 숫자까지만 입력 가능


#### 지갑 UI 
<img width="1438" alt="스크린샷 2022-05-11 오후 2 11 18" src="https://user-images.githubusercontent.com/85747667/167773601-5b9d0cc1-5445-4073-a841-baf9c14503fa.png">

- mock data 생성 및 적용

#### 공통
- 금액 표기시 천 단위로 , 를 표기하도록 함
 